### PR TITLE
Fix/amrfinder report contigs

### DIFF
--- a/bin/amr_report.py
+++ b/bin/amr_report.py
@@ -190,6 +190,8 @@ def location_parser(amr_data, mob_prots, mob_coords, mob_types):
                     to_output.write("\t".join([
                         protein_id, 
                         contig_id,
+                        str(amr_start),
+                        str(amr_end),
                         description,
                         location,
                         ])+ "\n")

--- a/bin/amr_report.py
+++ b/bin/amr_report.py
@@ -105,15 +105,14 @@ def mob_parser(mobilome):
     for protein_id in prots_loc:
         mges_loc = []
         prot_contig = prots_loc[protein_id][0]
-        prot_start = prots_loc[protein_id][1]
-        prot_end = prots_loc[protein_id][2]
-        print(prot_contig,prot_start,prot_end)
+        prot_start = int(prots_loc[protein_id][1])
+        prot_end = int(prots_loc[protein_id][2])
         prot_range = range(prot_start, prot_end + 1)
         prot_len = prot_end - prot_start
         if prot_contig in mob_coords:
             for mobile_element in mob_coords[prot_contig]:
-                mge_start = mobile_element[0]
-                mge_end = mobile_element[1]
+                mge_start = int(mobile_element[0])
+                mge_end = int(mobile_element[1])
                 mge_range = range(mge_start, mge_end + 1)
                 current_mge_type = mob_types[(prot_contig, mge_start, mge_end)]
                 intersection = len(list(set(mge_range) & set(prot_range)))

--- a/bin/amr_report.py
+++ b/bin/amr_report.py
@@ -102,7 +102,7 @@ def mob_parser(mobilome):
 
     # Adding the MGE type to each protein
     mob_prots = {}
-    for protein in prots_loc:
+    for protein_id in prots_loc:
         mges_loc = []
         prot_contig = prots_loc[protein_id][0]
         prot_start = prots_loc[protein_id][1]
@@ -122,9 +122,9 @@ def mob_parser(mobilome):
                         mges_loc.append(current_mge_type)
 
         if len(mges_loc)>0:
-            mob_prots[protein] = ';'.join(mges_loc)
+            mob_prots[protein_id] = ';'.join(mges_loc)
         else:
-            print("No MGE in the protein coordinates for protein "+protein+" in contig "+prot_contig)
+            print("No MGE in the protein coordinates for protein "+protein_id+" in contig "+prot_contig)
     
     return ( mob_prots, mob_coords, mob_types )
 

--- a/bin/amr_report.py
+++ b/bin/amr_report.py
@@ -8,7 +8,16 @@ import os.path
 ##### May 31, 2023
 
 
-def arg_parser(amr_out):
+def names_parser( contigs_map ):
+    contig_names = {}
+    with open(contigs_map, "r") as input_file:
+        for line in input_file:
+            pkka_name, fasta_name = line.rstrip().split("\t")
+            contig_names[pkka_name.replace(">", "")] = fasta_name
+    return contig_names
+
+
+def arg_parser(amr_out, contig_names):
     ### Saving amr predictions
     amr_data = {}
     if os.path.exists(amr_out):
@@ -18,23 +27,44 @@ def arg_parser(amr_out):
                 for line in input_csv:
                     line_l = line.rstrip().split("\t")
                     protein_id = line_l[0]
-                    e_type = line_l[4]
-                    e_stype = line_l[5]
-                    if e_type != e_stype:
-                        e_type = e_type + "|" + e_stype
-                    e_class = line_l[6]
-                    e_sclass = line_l[7]
-                    if e_class != e_sclass:
-                        e_class = e_class + "|" + e_sclass
-                    decriptors = (e_stype, e_class)
-                    amr_data[protein_id] = decriptors
-
+                    contig_id = contig_names[line_l[1]]
+                    start = int(line_l[2])
+                    end = int(line_l[3])
+                    strand = line_l[4]
+                    gene_name = line_l[5]
+                    sequence_name = line_l[6]
+                    aggregated_class = '|'.join([
+                        line_l[8],
+                        line_l[9],
+                        line_l[10],
+                        line_l[11],
+                    ])
+                    coverage = line_l[15]
+                    identity = line_l[16]
+                    descriptors = '\t'.join([
+                        coverage,
+                        identity,
+                        aggregated_class,
+                        gene_name,
+                        sequence_name
+                    ])
+                    composite_key = ( protein_id, contig_id, start, end, strand )
+                    amr_data[composite_key] = descriptors
     return amr_data
 
 
 def mob_parser(mobilome):
     ### Saving the proteins in the mobilome
-    mob_prots = []
+    mob_coords, mob_types, prots_loc = {}, {}, {}
+    mges_list = [
+        "conjugative_integron",
+        "insertion_sequence",
+        "integron",
+        "phage_plasmid",
+        "plasmid",
+        "prophage",
+        "viral_sequence",
+    ]
     with open(mobilome, "r") as input_gff:
         for line in input_gff:
             l_line = line.rstrip().split("\t")
@@ -52,39 +82,122 @@ def mob_parser(mobilome):
                     attr,
                 ) = line.rstrip().split("\t")
 
+                # Saving genes tagged as mobilome
                 if seq_type == "CDS":
                     att_fields = attr.split(";")
                     protein_id = att_fields[0].replace("ID=", "")
                     for attribute in att_fields:
                         if attribute == "location=mobilome":
-                            mob_prots.append(protein_id)
+                            prots_loc[protein_id] = ( contig, start, end )
 
-    return mob_prots
+                # Saving the MGEs coordinates
+                elif seq_type in mges_list: 
+                    coords_tuple = ( int(start), int(end) )
+                    if contig in mob_coords:
+                        mob_coords[contig].append(coords_tuple)
+                    else:
+                        mob_coords[contig] = [coords_tuple]
+                    composite_key = ( contig, int(start), int(end) )
+                    mob_types[composite_key] = seq_type
+
+    # Adding the MGE type to each protein
+    mob_prots = {}
+    for protein in prots_loc:
+        mges_loc = []
+        prot_contig = prots_loc[protein_id][0]
+        prot_start = prots_loc[protein_id][1]
+        prot_end = prots_loc[protein_id][2]
+        prot_range = range(prot_start, prot_end + 1)
+        prot_len = prot_end - prot_start
+        if prot_contig in mob_coords:
+            for mobile_element in mob_coords[prot_contig]:
+                mge_start = mobile_element[0]
+                mge_end = mobile_element[1]
+                mge_range = range(mge_start, mge_end + 1)
+                current_mge_type = mob_types[(prot_contig, mge_start, mge_end)]
+                intersection = len(list(set(mge_range) & set(prot_range)))
+                if intersection > 0:
+                    prot_cov = float(intersection) / float(prot_len)
+                    if prot_cov > 0.75:
+                        mges_loc.append(current_mge_type)
+
+        if len(mges_loc)>0:
+            mob_prots[protein] = ';'.join(mges_loc)
+        else:
+            print("No MGE in the protein coordinates for protein "+protein+" in contig "+prot_contig)
+    
+    return ( mob_prots, mob_coords, mob_types )
 
 
-def location_parser(amr_data, mob_prots):
+def location_parser(amr_data, mob_prots, mob_coords, mob_types):
     with open("amr_location.txt", "w") as to_output:
         to_output.write(
-            "\t".join(["Gene_id", "pred_type", "pred_class", "location"]) + "\n"
+            "\t".join([
+                "gene_id",
+                "contig_id", 
+                "ref_coverage",
+                "ref_identity",
+                "class_summary",
+                "ref_gene_name",
+                "ref_sequence_name",
+                "location"
+            ]) + "\n"
         )
-        for gene in amr_data:
-            prediction_type = amr_data[gene][0]
-            prediction_description = amr_data[gene][1]
-            if gene in mob_prots:
-                to_output.write(
-                    "\t".join(
-                        [gene, prediction_type, prediction_description, "mobilome"]
-                    )
-                    + "\n"
-                )
-            else:
-                to_output.write(
-                    "\t".join(
-                        [gene, prediction_type, prediction_description, "chromosome"]
-                    )
-                    + "\n"
-                )
+        
+        for composite_key in amr_data:
+            protein_id = composite_key[0]
+            contig_id = composite_key[1]
+            amr_start = composite_key[2]
+            amr_end = composite_key[3]
+            strand = composite_key[4]
+            description = amr_data[composite_key]
 
+            # When protein_id is NA, we need to check if the prediction coordinates are in the mobilome boundaries
+            if protein_id == 'NA':
+                mges_loc = []
+                if contig_id in mob_coords:
+                    amr_range = range( amr_start, amr_end + 1 )
+                    amr_len = amr_end - amr_start
+                    for mobile_element in mob_coords[contig_id]:
+                        mge_start = mobile_element[0]
+                        mge_end = mobile_element[1]
+                        mge_range = range(mge_start, mge_end + 1)
+                        current_mge_type = mob_types[(contig_id, mge_start, mge_end)]
+                        intersection = len(list(set(mge_range) & set(amr_range)))
+                        if intersection > 0:
+                            amr_cov = float(intersection) / float(amr_len)
+                            if amr_cov > 0.75:
+                                mges_loc.append(current_mge_type)
+                if len(mges_loc) > 0:
+                    location = 'mobilome:'+';'.join(mges_loc)
+                else:
+                    location = 'chromosome'
+
+                to_output.write("\t".join([
+                    protein_id, 
+                    contig_id,
+                    description,
+                    location,
+                ])+ "\n")
+            
+            else:
+                if protein_id in mob_prots:
+                    location = 'mobilome:'+mob_prots[protein_id]
+                    to_output.write("\t".join([
+                        protein_id, 
+                        contig_id,
+                        description,
+                        location,
+                        ])+ "\n")
+                else:
+                    location = 'chromosome'
+                    to_output.write("\t".join([
+                        protein_id, 
+                        contig_id,
+                        description,
+                        location,
+                    ])+ "\n")
+            
 
 def main():
     parser = argparse.ArgumentParser(
@@ -101,12 +214,19 @@ def main():
         help="ARG prediction output (amrfinderplus.tsv)",
         required=True,
     )
+    parser.add_argument(
+        "--contigs_map",
+        type=str,
+        help="Mapping file with contig names (contigID.map)",
+        required=True,
+    )
     args = parser.parse_args()
 
     ### Calling functions
-    amr_data = arg_parser(args.amr_out)
-    mob_prots = mob_parser(args.mobilome)
-    location_parser(amr_data, mob_prots)
+    contig_names = names_parser( args.contigs_map )
+    amr_data = arg_parser( args.amr_out, contig_names )
+    ( mob_prots, mob_coords, mob_types ) = mob_parser( args.mobilome )
+    location_parser( amr_data, mob_prots, mob_coords, mob_types )
 
 
 if __name__ == "__main__":

--- a/bin/amr_report.py
+++ b/bin/amr_report.py
@@ -107,6 +107,7 @@ def mob_parser(mobilome):
         prot_contig = prots_loc[protein_id][0]
         prot_start = prots_loc[protein_id][1]
         prot_end = prots_loc[protein_id][2]
+        print(prot_contig,prot_start,prot_end)
         prot_range = range(prot_start, prot_end + 1)
         prot_len = prot_end - prot_start
         if prot_contig in mob_coords:

--- a/bin/amr_report.py
+++ b/bin/amr_report.py
@@ -134,7 +134,9 @@ def location_parser(amr_data, mob_prots, mob_coords, mob_types):
         to_output.write(
             "\t".join([
                 "gene_id",
-                "contig_id", 
+                "contig_id",
+                "gene_start",
+                "gene_end",
                 "ref_coverage",
                 "ref_identity",
                 "class_summary",
@@ -176,6 +178,8 @@ def location_parser(amr_data, mob_prots, mob_coords, mob_types):
                 to_output.write("\t".join([
                     protein_id, 
                     contig_id,
+                    str(amr_start),
+                    str(amr_end),
                     description,
                     location,
                 ])+ "\n")
@@ -194,6 +198,8 @@ def location_parser(amr_data, mob_prots, mob_coords, mob_types):
                     to_output.write("\t".join([
                         protein_id, 
                         contig_id,
+                        str(amr_start),
+                        str(amr_end),
                         description,
                         location,
                     ])+ "\n")

--- a/main.nf
+++ b/main.nf
@@ -156,7 +156,7 @@ workflow {
 
     if ( !params.skip_amr ) {
         AMRFINDER_PLUS( PROKKA.out.prokka_fna, PROKKA.out.prokka_faa, PROKKA.out.prokka_gff )
-        AMRFINDER_REPORT( AMRFINDER_PLUS.out.amrfinder_tsv, INTEGRATOR.out.mobilome_prokka_gff )
+        AMRFINDER_REPORT( AMRFINDER_PLUS.out.amrfinder_tsv, INTEGRATOR.out.mobilome_prokka_gff, RENAME.out.map_file )
     }
 
 }

--- a/modules/amrfinder_report.nf
+++ b/modules/amrfinder_report.nf
@@ -9,6 +9,7 @@ process AMRFINDER_REPORT {
     input:
     path amrfinder_tsv
     path mobilome_gff
+    path map_file
 
     output:
     path("amr_location.txt")
@@ -18,6 +19,7 @@ process AMRFINDER_REPORT {
     amr_report.py \
     --amr_out ${amrfinder_tsv} \
     --mobilome ${mobilome_gff} \
+    --contigs_map ${map_file}
     """
 }
 


### PR DESCRIPTION
AMRfinderplus report improvement. New fields were added to the table and the type of the MGE is now specified when location = mobilome. An output example:

```bash
gene_id	contig_id	gene_start	gene_end	ref_coverage	ref_identity	class_summary	ref_gene_name	ref_sequence_name	location
GNBBHOPO_00175	ERZ13633678.1-NODE-1-length-230215-cov-8.265911	182476	183627	100.00	100.00	AMR|AMR|EFFLUX|EFFLUX	mexA	multidrug efflux RND transporter periplasmic adaptor subunit MexA	chromosome
NA	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	3	275	63.19	100.00	STRESS|METAL|MERCURY|MERCURY	merR	mercury resistance transcriptional regulator MerR	mobilome:plasmid
GNBBHOPO_02489	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	347	697	100.00	100.00	STRESS|METAL|MERCURY|MERCURY	merT	mercuric transport protein MerT	mobilome:plasmid
GNBBHOPO_02490	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	711	986	100.00	100.00	STRESS|METAL|MERCURY|MERCURY	merP	mercury resistance system periplasmic binding protein MerP	mobilome:plasmid
GNBBHOPO_02491	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	1174	2883	100.00	98.95	STRESS|METAL|MERCURY|MERCURY	merA	mercury(II) reductase	mobilome:plasmid
GNBBHOPO_02492	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	2919	3572	100.00	100.00	STRESS|METAL|MERCURY|PHENYLMERCURY	merG	phenylmercury resistance protein MerG	mobilome:plasmid
GNBBHOPO_02493	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	3653	4291	100.00	99.53	STRESS|METAL|MERCURY|ORGANOMERCURY	merB	organomercurial lyase MerB	mobilome:plasmid
GNBBHOPO_02495	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	5269	5703	100.00	100.00	STRESS|METAL|MERCURY|MERCURY	merR	mercury resistance transcriptional regulator MerR	mobilome:plasmid
GNBBHOPO_02497	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	6001	6639	100.00	100.00	STRESS|METAL|MERCURY|ORGANOMERCURY	merB	organomercurial lyase MerB	mobilome:plasmid
GNBBHOPO_02498	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	6751	7116	100.00	100.00	STRESS|METAL|MERCURY|MERCURY	merD	mercury resistance co-regulator MerD	mobilome:plasmid
GNBBHOPO_02499	ERZ13633678.18-NODE-18-length-106543-cov-7.185880	7113	7349	98.72	85.71	STRESS|METAL|MERCURY|MERCURY	merE	broad-spectrum mercury transporter MerE	mobilome:plasmid
GNBBHOPO_04276	ERZ13633678.41-NODE-41-length-61116-cov-8.431912	41031	41819	100.00	100.00	AMR|AMR|BETA-LACTAM|BETA-LACTAM	blaOXA-488	OXA-50 family oxacillin-hydrolyzing class D beta-lactamase OXA-488	chromosome
```