### PR TITLE
Fix/user mobilome clean

### DIFF
--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -105,7 +105,7 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, mges_dict, mob_types )
                                 mge_label = mob_types[( contig, mge_start, mge_end  )]
                                 intersection = len(list(set(mge_range) & set(u_prot_range)))
                                 if intersection > 0:
-                                    u_prot_cov = float(intersection) / float(prot_len)
+                                    u_prot_cov = float(intersection) / float(u_prot_len)
                                     if u_prot_cov > 0.75:
                                         passenger_flag = 1
                                         mge_loc.append(mge_label)

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -95,6 +95,7 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, clean_proteins):
                             output_clean.write(line.rstrip() + ";" + extra_annot + "\n")                        
                     elif composite_val in clean_proteins:
                         output_clean.write(line.rstrip() + "\n")
+                        output_full.write(line.rstrip() + "\n")
                     else:
                         output_full.write(line.rstrip() + "\n")
                 

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -13,9 +13,7 @@ import glob
 
 def mobilome_parser( mobilome_clean ):
     # Parsing the mobilome prediction
-    proteins_annot, mobilome_annot = {}, {}
-    clean_proteins = []
-
+    proteins_annot, mobilome_annot, mges_dict, mob_types = {}, {}, {}, {}
     source_tools = [
         "ICEfinder",
         "IntegronFinder",
@@ -31,7 +29,7 @@ def mobilome_parser( mobilome_clean ):
         "viphog_taxonomy",
         "mobileOG",
     ]
-
+    
     if os.stat(mobilome_clean).st_size > 0:
         with open(mobilome_clean, "r") as input_table:
             for line in input_table:
@@ -40,17 +38,22 @@ def mobilome_parser( mobilome_clean ):
                 if len(l_line) == 9:
                     contig = l_line[0]
                     annot_source = l_line[1]
+                    seq_type = l_line[2]
+                    start = int(l_line[3])
+                    end = int(l_line[4])
+                    strand = l_line[6]
+                    coordinates = (start, end)
                     if annot_source in source_tools:
+                        composite_key = ( contig, start, end )
+                        mob_types[composite_key] = seq_type                        
                         if contig in mobilome_annot:
                             mobilome_annot[contig].append(line.rstrip())
+                            mges_dict[contig].append(coordinates)
                         else:
                             mobilome_annot[contig] = [line.rstrip()]
+                            mges_dict[contig] = [coordinates]
                     else:
-                        start = l_line[3]
-                        end = l_line[4]
-                        strand = l_line[6]
-                        composite_key = (contig, start, end, strand)
-                        clean_proteins.append(composite_key)
+                        str_composite_key = (contig, str(start), str(end), strand)
                         attrib = l_line[8]
                         extra_list = []
                         for attr in attrib.split(";"):
@@ -60,13 +63,13 @@ def mobilome_parser( mobilome_clean ):
                                 extra_list.append(attr)
                         if len(extra_list) > 0:
                             extra_val = ";".join(extra_list)
-                            proteins_annot[composite_key] = extra_val
+                            proteins_annot[str_composite_key] = extra_val
 
-    return (proteins_annot, mobilome_annot, clean_proteins)
+    return (proteins_annot, mobilome_annot, mges_dict, mob_types)
 
 
 # Adding the mobilome predictions to the user file
-def gff_updater(user_gff, proteins_annot, mobilome_annot, clean_proteins):
+def gff_updater(user_gff, proteins_annot, mobilome_annot, mges_dict, mob_types ):
     used_contigs = []
     if os.stat(user_gff).st_size > 0:
         with open(user_gff, "r") as input_table, open("user_mobilome_extra.gff", "w") as output_extra, open("user_mobilome_full.gff", "w") as output_full, open("user_mobilome_clean.gff", "w") as output_clean:
@@ -78,24 +81,46 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, clean_proteins):
                     start = l_line[3]
                     end = l_line[4]
                     strand = l_line[6]
+                    composite_val = (contig, start, end, strand)
                     if not contig in used_contigs:
                         used_contigs.append(contig)
+                        # Writing the mobilome entries in every output
                         if contig in mobilome_annot:
                             for mge in mobilome_annot[contig]:
                                 output_clean.write(mge + "\n")
                                 output_extra.write(mge + "\n")
                                 output_full.write(mge + "\n")
 
-                    composite_val = (contig, start, end, strand)                    
+                            # Finding mobilome proteins in the user file
+                            u_prot_start = int(start)
+                            u_prot_end = int(end)
+                            u_prot_range = range(u_prot_start, u_prot_end + 1)
+                            u_prot_len = u_prot_end - u_prot_start
+                            passenger_flag = 0
+                            mge_loc = []
+                            for coordinates in mges_dict[contig]:
+                                mge_start = coordinates[0]
+                                mge_end = coordinates[1]
+                                mge_range = range(mge_start, mge_end + 1)
+                                mge_label = mob_types[( contig, mge_start, mge_end  )]
+                                intersection = len(list(set(mge_range) & set(u_prot_range)))
+                                if intersection > 0:
+                                    u_prot_cov = float(intersection) / float(prot_len)
+                                    if u_prot_cov > 0.75:
+                                        passenger_flag = 1
+                                        mge_loc.append(mge_label)
+                            if passenger_flag == 1:
+                                mge_loc = 'mge_location=' + ','.join(mge_loc)
+                                if composite_val in proteins_annot:
+                                    extra_annot = proteins_annot[composite_val]
+                                    output_clean.write(line.rstrip() + ";" + extra_annot + ";" + mge_loc + "\n")
+                                else:
+                                    output_clean.write(line.rstrip() + ";" + mge_loc + "\n"
+                                        
                     if composite_val in proteins_annot:
                         extra_annot = proteins_annot[composite_val]
                         output_extra.write(line.rstrip() + ";" + extra_annot + "\n")
                         output_full.write(line.rstrip() + ";" + extra_annot + "\n")
-                        if composite_val in clean_proteins:
-                            output_clean.write(line.rstrip() + ";" + extra_annot + "\n")                        
-                    elif composite_val in clean_proteins:
-                        output_clean.write(line.rstrip() + "\n")
-                        output_full.write(line.rstrip() + "\n")
                     else:
                         output_full.write(line.rstrip() + "\n")
                 
@@ -124,10 +149,10 @@ def main():
 
     ## Calling functions
     # Storing the mobilome predictions
-    ( proteins_annot, mobilome_annot, clean_proteins ) = mobilome_parser(args.mobilome_clean)
+    ( proteins_annot, mobilome_annot, mges_dict, mob_types ) = mobilome_parser(args.mobilome_clean)
 
     # Adding the mobilome predictions to the user file
-    gff_updater( args.user_gff, proteins_annot, mobilome_annot, clean_proteins )
+    gff_updater( args.user_gff, proteins_annot, mobilome_annot, mges_dict, mob_types )
 
 
 if __name__ == "__main__":

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -86,7 +86,6 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, clean_proteins):
                                 output_extra.write(mge + "\n")
                                 output_full.write(mge + "\n")
 
-                    output_full.write(line.rstrip() + "\n")
                     composite_val = (contig, start, end, strand)                    
                     if composite_val in proteins_annot:
                         extra_annot = proteins_annot[composite_val]
@@ -96,7 +95,9 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, clean_proteins):
                             output_clean.write(line.rstrip() + ";" + extra_annot + "\n")                        
                     elif composite_val in clean_proteins:
                         output_clean.write(line.rstrip() + "\n")
-
+                    else:
+                        output_full.write(line.rstrip() + "\n")
+                
                 else:
                     output_clean.write(line.rstrip() + "\n")
                     output_extra.write(line.rstrip() + "\n")

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -91,39 +91,40 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, mges_dict, mob_types )
                                 output_extra.write(mge + "\n")
                                 output_full.write(mge + "\n")
 
-                            # Finding mobilome proteins in the user file
-                            u_prot_start = int(start)
-                            u_prot_end = int(end)
-                            u_prot_range = range(u_prot_start, u_prot_end + 1)
-                            u_prot_len = u_prot_end - u_prot_start
-                            passenger_flag = 0
-                            mge_loc = []
-                            for coordinates in mges_dict[contig]:
-                                mge_start = coordinates[0]
-                                mge_end = coordinates[1]
-                                mge_range = range(mge_start, mge_end + 1)
-                                mge_label = mob_types[( contig, mge_start, mge_end  )]
-                                intersection = len(list(set(mge_range) & set(u_prot_range)))
-                                if intersection > 0:
-                                    u_prot_cov = float(intersection) / float(u_prot_len)
-                                    if u_prot_cov > 0.75:
-                                        passenger_flag = 1
-                                        mge_loc.append(mge_label)
-                            if passenger_flag == 1:
-                                mge_loc = 'mge_location=' + ','.join(mge_loc)
-                                if composite_val in proteins_annot:
-                                    extra_annot = proteins_annot[composite_val]
-                                    output_clean.write(line.rstrip() + ";" + extra_annot + ";" + mge_loc + "\n")
-                                else:
-                                    output_clean.write(line.rstrip() + ";" + mge_loc + "\n" )
-                                        
+                    # Writing to extra and full outputs
                     if composite_val in proteins_annot:
                         extra_annot = proteins_annot[composite_val]
                         output_extra.write(line.rstrip() + ";" + extra_annot + "\n")
                         output_full.write(line.rstrip() + ";" + extra_annot + "\n")
                     else:
                         output_full.write(line.rstrip() + "\n")
-                
+                    
+                    # Finding mobilome proteins in the user file and writing to clean output
+                    u_prot_start = int(start)
+                    u_prot_end = int(end)
+                    u_prot_range = range(u_prot_start, u_prot_end + 1)
+                    u_prot_len = u_prot_end - u_prot_start
+                    passenger_flag = 0
+                    mge_loc = []
+                    if contig in mobilome_annot:
+                        for coordinates in mges_dict[contig]:
+                            mge_start = coordinates[0]
+                            mge_end = coordinates[1]
+                            mge_range = range(mge_start, mge_end + 1)
+                            mge_label = mob_types[( contig, mge_start, mge_end  )]
+                            intersection = len(list(set(mge_range) & set(u_prot_range)))
+                            if intersection > 0:
+                                u_prot_cov = float(intersection) / float(u_prot_len)
+                                if u_prot_cov > 0.75:
+                                    passenger_flag = 1
+                                    mge_loc.append(mge_label)
+                        if passenger_flag == 1:
+                            mge_loc = 'mge_location=' + ','.join(mge_loc)
+                            if composite_val in proteins_annot:
+                                extra_annot = proteins_annot[composite_val]
+                                output_clean.write(line.rstrip() + ";" + extra_annot + ";" + mge_loc + "\n")
+                            else:
+                                output_clean.write(line.rstrip() + ";" + mge_loc + "\n" )
                 else:
                     output_clean.write(line.rstrip() + "\n")
                     output_extra.write(line.rstrip() + "\n")

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -115,7 +115,7 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, mges_dict, mob_types )
                                     extra_annot = proteins_annot[composite_val]
                                     output_clean.write(line.rstrip() + ";" + extra_annot + ";" + mge_loc + "\n")
                                 else:
-                                    output_clean.write(line.rstrip() + ";" + mge_loc + "\n"
+                                    output_clean.write(line.rstrip() + ";" + mge_loc + "\n" )
                                         
                     if composite_val in proteins_annot:
                         extra_annot = proteins_annot[composite_val]

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -82,6 +82,7 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot, extra_proteins):
                         used_contigs.append(contig)
                         if contig in mobilome_annot:
                             for mge in mobilome_annot[contig]:
+                                output_clean.write(mge + "\n")
                                 output_extra.write(mge + "\n")
                                 output_full.write(mge + "\n")
 

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -11,9 +11,10 @@ import glob
 ##### October 19, 2023
 
 
-def mobilome_parser(mobilome_prokka_extra):
+def mobilome_parser( mobilome_clean ):
     # Parsing the mobilome prediction
     proteins_annot, mobilome_annot = {}, {}
+    extra_proteins = []
 
     source_tools = [
         "ICEfinder",
@@ -31,8 +32,8 @@ def mobilome_parser(mobilome_prokka_extra):
         "mobileOG",
     ]
 
-    if os.stat(mobilome_prokka_extra).st_size > 0:
-        with open(mobilome_prokka_extra, "r") as input_table:
+    if os.stat(mobilome_clean).st_size > 0:
+        with open(mobilome_clean, "r") as input_table:
             for line in input_table:
                 l_line = line.rstrip().split("\t")
                 # Annotation lines have exactly 9 columns
@@ -57,19 +58,18 @@ def mobilome_parser(mobilome_prokka_extra):
                             if att_key in extra_annot:
                                 extra_list.append(attr)
                         if len(extra_list) > 0:
+                            extra_proteins.append(composite_key)
                             extra_val = ";".join(extra_list)
                             proteins_annot[composite_key] = extra_val
 
-    return (proteins_annot, mobilome_annot)
+    return (proteins_annot, mobilome_annot, extra_proteins)
 
 
 # Adding the mobilome predictions to the user file
-def gff_updater(user_gff, proteins_annot, mobilome_annot):
+def gff_updater(user_gff, proteins_annot, mobilome_annot, extra_proteins):
     used_contigs = []
     if os.stat(user_gff).st_size > 0:
-        with open(user_gff, "r") as input_table, open(
-            "user_mobilome_extra.gff", "w"
-        ) as output_table, open("user_mobilome_full.gff", "w") as output_full:
+        with open(user_gff, "r") as input_table, open("user_mobilome_extra.gff", "w") as output_extra, open("user_mobilome_full.gff", "w") as output_full, open("user_mobilome_clean.gff", "w") as output_clean:
             for line in input_table:
                 l_line = line.rstrip().split("\t")
                 # Annotation lines have exactly 9 columns
@@ -82,19 +82,23 @@ def gff_updater(user_gff, proteins_annot, mobilome_annot):
                         used_contigs.append(contig)
                         if contig in mobilome_annot:
                             for mge in mobilome_annot[contig]:
-                                output_table.write(mge + "\n")
+                                output_extra.write(mge + "\n")
                                 output_full.write(mge + "\n")
 
                     composite_val = (contig, start, end, strand)
                     if composite_val in proteins_annot:
                         extra_annot = proteins_annot[composite_val]
-                        output_table.write(line.rstrip() + ";" + extra_annot + "\n")
+                        output_clean.write(line.rstrip() + ";" + extra_annot + "\n")
                         output_full.write(line.rstrip() + ";" + extra_annot + "\n")
+                        if composite_val in extra_proteins:
+                            output_extra.write(line.rstrip() + ";" + extra_annot + "\n")
+
                     else:
                         output_full.write(line.rstrip() + "\n")
 
                 else:
-                    output_table.write(line.rstrip() + "\n")
+                    output_clean.write(line.rstrip() + "\n")
+                    output_extra.write(line.rstrip() + "\n")
                     output_full.write(line.rstrip() + "\n")
 
 def main():
@@ -102,9 +106,9 @@ def main():
         description="This script add the extra annotations to the user GFF file"
     )
     parser.add_argument(
-        "--mobilome_prokka_extra",
+        "--mobilome_clean",
         type=str,
-        help="Mobilome prediction on prokka gff file containing the mobilome proteins with extra annotation only",
+        help="Mobilome prediction on prokka gff file containing the mobilome proteins",
         required=True,
     )
     parser.add_argument(
@@ -117,10 +121,10 @@ def main():
 
     ## Calling functions
     # Storing the mobilome predictions
-    (proteins_annot, mobilome_annot) = mobilome_parser(args.mobilome_prokka_extra)
+    ( proteins_annot, mobilome_annot, extra_proteins ) = mobilome_parser(args.mobilome_clean)
 
     # Adding the mobilome predictions to the user file
-    gff_updater(args.user_gff, proteins_annot, mobilome_annot)
+    gff_updater( args.user_gff, proteins_annot, mobilome_annot, extra_proteins )
 
 
 if __name__ == "__main__":

--- a/main.nf
+++ b/main.nf
@@ -147,7 +147,7 @@ workflow {
 
     if ( params.user_genes ) {
         user_gff = Channel.fromPath( params.prot_gff, checkIfExists: true )
-        GFF_MAPPING( GFF_REDUCE.out.mobilome_extra, user_gff )
+        GFF_MAPPING( GFF_REDUCE.out.mobilome_clean, user_gff )
     }
 
     if ( params.gff_validation ) {

--- a/modules/gff_mapping.nf
+++ b/modules/gff_mapping.nf
@@ -7,17 +7,18 @@ process GFF_MAPPING {
     container 'quay.io/biocontainers/python:3.9--1'
 
     input:
-    path mobilome_extra
-	path user_gff
+    path mobilome_clean
+    path user_gff
 
     output:
-	path "user_mobilome_extra.gff"
-	path "user_mobilome_full.gff"
+    path "user_mobilome_extra.gff"
+    path "user_mobilome_full.gff"
+    path "user_mobilome_clean.gff"
 
     script:
     """
     gff_mapping.py \
-    --mobilome_prokka_extra ${mobilome_extra} \
+    --mobilome_clean ${mobilome_clean} \
     --user_gff ${user_gff}
     """
 }

--- a/modules/gff_reduce.nf
+++ b/modules/gff_reduce.nf
@@ -12,8 +12,8 @@ process GFF_REDUCE {
 
     output:
     path "mobilome_clean.gff", emit: mobilome_clean
-	path "mobilome_extra.gff", emit: mobilome_extra
-	path "mobilome_nogenes.gff", emit: mobilome_nogenes
+    path "mobilome_extra.gff", emit: mobilome_extra
+    path "mobilome_nogenes.gff", emit: mobilome_nogenes
 
     script:
     """


### PR DESCRIPTION
The `user_mobilome_clean.gff` output is now generated and includes an extra key in the attributes column to label the type of MGE the CDS belongs to