### PR TITLE
Some fixes for CRISPRCasFinder

### DIFF
--- a/modules/crisprcas.nf
+++ b/modules/crisprcas.nf
@@ -5,17 +5,21 @@ process CRISPR_FINDER {
 
     publishDir "$params.outdir/func_annot", mode: 'copy'
 
-    container 'quay.io/microbiome-informatics/genomes-pipeline.crisprcasfinder:4.3.2'
+    container 'quay.io/microbiome-informatics/genomes-pipeline.crisprcasfinder:4.3.2patchedv5'
 
     input:
-        path contigs
+    path contigs
 
     output:
-        path("crispr_results/TSV/Crisprs_REPORT.tsv"), emit: crispr_report
+    path("crispr_results/TSV/Crisprs_REPORT.tsv"), emit: crispr_report
 
     script:
-    if(contigs.size() > 0)
+    if ( contigs.size() > 0 )
        """
+        # CRISPRCasFinder doesn't like it if the folder is there already, which could happen
+        # when retrying this process
+        rm -rf crispr_results || true
+
        CRISPRCasFinder.pl \
        -i ${contigs} \
        -so ${params.crispr_so} \
@@ -30,5 +34,4 @@ process CRISPR_FINDER {
         echo 'CRISPRCasFinder output file empty due to empty input... generating dummy files'
         mkdir -r crispr_results/TSV && touch crispr_results/TSV/Crisprs_REPORT.tsv 
         """
-
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,6 +34,8 @@ params {
 
     // ICEfinder .sif path //
     icefinder_sif = ''
+
+    singularity_cachedir = ''
 }
 
 


### PR DESCRIPTION
Some fixes for CRISPRCasFinder. 

Testing a modified version, please see -> https://github.com/dcouvin/CRISPRCasFinder/pull/57.

Add "rm -r" the results folder in for retries in this module.

Should close https://github.com/EBI-Metagenomics/mobilome-annotation-pipeline/issues/37