### PR TITLE
geNomad, IntegronFinder2, ISEScan version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,10 +256,10 @@ The Mobilome Annotation Pipeline parses and integrates the output of the followi
 
 - AMRFinderPlus v3.11.4 with database v2023-02-23.1 [Feldgarden et al., Sci Rep, 2021](https://doi.org/10.1038/s41598-021-91456-0)
 - Diamond v2.0.12 [Buchfink et al., Nature Methods, 2021](https://doi.org/10.1038/s41592-021-01101-x)
-- geNomad v1.6.1 [Camargo et al., Nature Biotechnology, 2023](https://doi.org/10.1038/s41587-023-01953-y)
+- geNomad v1.11.1 [Camargo et al., Nature Biotechnology, 2023](https://doi.org/10.1038/s41587-023-01953-y)
 - ICEfinder v1.0 [Liu et al., Nucleic Acids Res, 2019](https://doi.org/10.1093/nar/gky1123)
-- IntegronFinder2 v2.0.2 [Néron et al., Microorganisms, 2022](https://doi.org/10.3390/microorganisms10040700)
-- ISEScan v1.7.2.3 [Xie et al., Bioinformatics, 2017](https://doi.org/10.1093/bioinformatics/btx433)
+- IntegronFinder2 v2.0.6 [Néron et al., Microorganisms, 2022](https://doi.org/10.3390/microorganisms10040700)
+- ISEScan v1.7.3 [Xie et al., Bioinformatics, 2017](https://doi.org/10.1093/bioinformatics/btx433)
 - MobileOG-DB Beatrix 1.6 v1 [Brown et al., Appl Environ Microbiol, 2022](https://doi.org/10.1128/aem.00991-22)
 - PROKKA v1.14.6 [Seemann, Bioinformatics, 2014](https://doi.org/10.1093/bioinformatics/btu153)
 - VIRify v3.0.0 [Rangel-Pineros et al., PLoS Comput Biol, 2023](https://doi.org/10.1371/journal.pcbi.1011422)

--- a/bin/map_tools/integronfinder_process.py
+++ b/bin/map_tools/integronfinder_process.py
@@ -21,11 +21,18 @@ from Bio import SeqIO
 def integron_parser(mge_data, integron_results, inf_gbks):
     ### Parsing IntegronFinder summary file
     gbk_files_list = []
+    header_skipped = False
     if os.stat(integron_results).st_size > 0:
         with open(integron_results, "r") as input_table:
-            next(input_table)
-            next(input_table)
+            # Different versions of IntegronFinder produce different number of header lines
+            # Skip any line starting with # and the header
             for line in input_table:
+                if line.startswith("#"):
+                    continue
+                if not header_skipped:
+                    # Skipping the first line that doesn't start with "#" which is the header
+                    header_skipped = True
+                    continue
                 id_replicon, calin, complete, in0, topology, size = line.rstrip().split(
                     "\t"
                 )

--- a/bin/map_tools/integronfinder_process.py
+++ b/bin/map_tools/integronfinder_process.py
@@ -21,7 +21,7 @@ from Bio import SeqIO
 def integron_parser(mge_data, integron_results, inf_gbks):
     ### Parsing IntegronFinder summary file
     gbk_files_list = []
-    header_skipped = False
+    header_checked = False
     if os.stat(integron_results).st_size > 0:
         with open(integron_results, "r") as input_table:
             # Different versions of IntegronFinder produce a different number of header lines
@@ -29,13 +29,16 @@ def integron_parser(mge_data, integron_results, inf_gbks):
             for line in input_table:
                 if line.startswith("#"):
                     continue
-                if not header_skipped:
-                    # Skipping the header (first line that doesn't start with "#")
-                    header_skipped = True
-                    continue
+
                 id_replicon, calin, complete, in0, topology, size = line.rstrip().split(
                     "\t"
                 )
+
+                if not header_checked:
+                    header_checked = True  # We only want to check the first line after the "#" lines
+                    # Confirm that this is the header in case future tool versions produce a different format
+                    if not str(complete).isdigit():  # If "complete" is not a digit, this is the header, not a value
+                        continue
 
                 # Saving gbk file names of complete integrons
                 if int(complete) > 0:

--- a/bin/map_tools/integronfinder_process.py
+++ b/bin/map_tools/integronfinder_process.py
@@ -24,13 +24,13 @@ def integron_parser(mge_data, integron_results, inf_gbks):
     header_skipped = False
     if os.stat(integron_results).st_size > 0:
         with open(integron_results, "r") as input_table:
-            # Different versions of IntegronFinder produce different number of header lines
+            # Different versions of IntegronFinder produce a different number of header lines
             # Skip any line starting with # and the header
             for line in input_table:
                 if line.startswith("#"):
                     continue
                 if not header_skipped:
-                    # Skipping the first line that doesn't start with "#" which is the header
+                    # Skipping the header (first line that doesn't start with "#")
                     header_skipped = True
                     continue
                 id_replicon, calin, complete, in0, topology, size = line.rstrip().split(

--- a/conf/codon_dbs.config
+++ b/conf/codon_dbs.config
@@ -7,6 +7,6 @@
 params {
     amrfinder_plus_db    = "/hps/nobackup/rdf/metagenomics/service-team/ref-dbs/amrfinderplus/3.11/2023-02-23.1"
     mobileog_db          = "/hps/nobackup/rdf/metagenomics/service-team/ref-dbs/diamond_dbs/mobileOG_beatrix1.6.dmnd"
-    genomad_db           = "/hps/nobackup/rdf/metagenomics/service-team/ref-dbs/genomad_151/"
+    genomad_db           = "/hps/nobackup/rdf/metagenomics/service-team/ref-dbs/genomad/1.9"
     icefinder_sif        =  "/hps/nobackup/rdf/metagenomics/service-team/singularity-cache/icefinder-v1.0-local.sif"
 }

--- a/modules/genomad.nf
+++ b/modules/genomad.nf
@@ -3,8 +3,8 @@ process GENOMAD {
     label 'process_medium'
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/genomad:1.6.1--pyhdfd78af_0':
-        'biocontainers/genomad:1.6.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/genomad:1.11.1--pyhdfd78af_0':
+        'biocontainers/genomad:1.11.1--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(assembly_file)

--- a/modules/integronfinder.nf
+++ b/modules/integronfinder.nf
@@ -2,7 +2,7 @@ process INTEGRONFINDER {
     tag "$meta.id"
     label 'process_high'
 
-    container 'gempasteur/integron_finder:2.0.6'
+    container 'quay.io/biocontainers/integron_finder:2.0.6--pyhdfd78af_0'
 
     input:
     tuple val(meta), path(assembly_file)

--- a/modules/integronfinder.nf
+++ b/modules/integronfinder.nf
@@ -2,7 +2,7 @@ process INTEGRONFINDER {
     tag "$meta.id"
     label 'process_high'
 
-    container 'quay.io/microbiome-informatics/integronfinder:71ee6e0'
+    container 'gempasteur/integron_finder:2.0.6'
 
     input:
     tuple val(meta), path(assembly_file)

--- a/modules/isescan.nf
+++ b/modules/isescan.nf
@@ -2,7 +2,7 @@ process ISESCAN {
     tag "$meta.id"
     label 'process_high'
 
-    container 'quay.io/microbiome-informatics/isescan-v1.7.2.3'
+    container 'quay.io/biocontainers/isescan:1.7.3--h7b50bb2_0'
 
     input:
     tuple val(meta), path(assembly_file)


### PR DESCRIPTION
Updated tools:
geNomad v1.6.1 -> v1.11.1
geNomad db -> v1.9
IntegronFinder2 v2.0.2 -> v2.0.6
ISEScan v1.7.2.3 -> v1.7.3

The IntegronFinder parser script was modified to correctly handle header skipping in different output versions.