### PR TITLE
Setting the amrfinder_plus databases as a path

### DIFF
--- a/modules/local/amrfinder_plus.nf
+++ b/modules/local/amrfinder_plus.nf
@@ -9,6 +9,7 @@ process AMRFINDER_PLUS {
 
     input:
     tuple val(meta), path(fna), path(faa), path(gff)
+    path(amrfinder_plus_db)
 
     output:
     tuple val(meta), path("*_amrfinderplus.tsv"), emit: amrfinder_tsv
@@ -21,7 +22,7 @@ process AMRFINDER_PLUS {
         -n ${fna} \\
         -p ${faa} \\
         -g ${gff} \\
-        -d ${params.amrfinder_plus_db} \\
+        -d ${amrfinder_plus_db} \\
         -a prokka \\
         --output ${prefix}_amrfinderplus.tsv \\
         --threads ${task.cpus}

--- a/workflows/mobilomeannotation.nf
+++ b/workflows/mobilomeannotation.nf
@@ -204,7 +204,9 @@ workflow MOBILOMEANNOTATION {
     // AMRFinder is optional. default skip_amr = FALSE
     def amr_finder_ch = PROKKA.out.prokka_fna.join(PROKKA.out.prokka_faa).join(PROKKA.out.prokka_gff).filter { it -> !it[0].skip_amrfinder_plus }
 
-    AMRFINDER_PLUS(amr_finder_ch)
+    amrfinder_plus_db = file(params.amrfinder_plus_db, checkIfExists: true)
+
+    AMRFINDER_PLUS(amr_finder_ch, amrfinder_plus_db)
     ch_versions = ch_versions.mix(AMRFINDER_PLUS.out.versions)
 
     AMRFINDER_REPORT(


### PR DESCRIPTION
This change is necessary to fix the issue #58. The amrfinder process is not handling the database as a path so it's not mounting the directory properly in your system (or any system using docker/singularity).