### PR TITLE
Updating aragorn flags to match prokka

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -14,9 +14,8 @@
 process {
     withName: ARAGORN {
         ext.args = [
+            "-l",
             "-w",
-            "-i",
-            "-t",
             "-gc1",
         ].join(' ')
     }


### PR DESCRIPTION
Aragorn flags were updated to avoid reporting introns, which was producing 1-nt tRNA when parsing coordinates