### PR TITLE
Only run IntegronFinder for contigs > 100kb

### DIFF
--- a/modules/local/integronfinder.nf
+++ b/modules/local/integronfinder.nf
@@ -21,11 +21,11 @@ process INTEGRONFINDER {
         --gbk \\
         ${assembly_file}
 
-    if ls -l Results_Integron_Finder_${prefix}_5kb_contigs/*.gbk 2>/dev/null | grep -q .
+    if ls -l Results_Integron_Finder_${prefix}_100kb_contigs/*.gbk 2>/dev/null | grep -q .
     then
         echo 'IntegronFinder outputs complete'
-        mv Results_Integron_Finder_${prefix}_5kb_contigs/*.gbk .
-        mv Results_Integron_Finder_${prefix}_5kb_contigs/*.summary .
+        mv Results_Integron_Finder_${prefix}_100kb_contigs/*.gbk .
+        mv Results_Integron_Finder_${prefix}_100kb_contigs/*.summary .
     else
         echo 'IntegronFinder found 0 integrons in assembly... generating dummy files'
         touch contig_dummy.gbk

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -41,11 +41,11 @@
                 "neg_test_contigID.map:md5,ee5ba049c3a2a21071310f387b9ed274"
             ]
         ],
+        "timestamp": "2025-11-17T14:34:31.916847",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-11-17T14:34:31.916847"
+        }
     },
     "Positive test of the Mobilome annotation pipeline with user proteins and VIRify input": {
         "content": [
@@ -77,9 +77,8 @@
                 "pos_test/prediction/icefinder2lite/pos_test_ice_genes.tsv",
                 "pos_test/prediction/icefinder2lite/pos_test_ices.tsv",
                 "pos_test/prediction/integronfinder",
-                "pos_test/prediction/integronfinder/contig_1.gbk",
-                "pos_test/prediction/integronfinder/contig_5.gbk",
-                "pos_test/prediction/integronfinder/pos_test_5kb_contigs.summary",
+                "pos_test/prediction/integronfinder/contig_dummy.gbk",
+                "pos_test/prediction/integronfinder/contig_dummy.summary",
                 "pos_test/prediction/isescan",
                 "pos_test/prediction/isescan/pos_test_1kb_contigs.fasta.tsv",
                 "pos_test/prediction/virify_filter",
@@ -91,24 +90,23 @@
                 "pos_test/preprocessing/pos_test_contigID.map"
             ],
             [
-                "pos_test_mobilome.gff.gz:md5,4dafb2b081c7fd9f88ac42019f9623fb",
-                "pos_test_user_mobilome_clean.gff.gz:md5,ce8598c38077a68a73386a6bea9ebb01",
-                "pos_test_user_mobilome_clean.gff.gz.csi:md5,f4ccc92f5dc649d5171b86f2ccd09bd8",
-                "pos_test_user_mobilome_extra.gff.gz:md5,d3b28208f6b792040e8ad51555de1c81",
-                "pos_test_user_mobilome_extra.gff.gz.csi:md5,db7aa2d1bb9749f606b16c4f7fe1a89d",
-                "pos_test_user_mobilome_full.gff.gz:md5,15d68d8e29e45902d418ca449a9238ce",
-                "pos_test_user_mobilome_full.gff.gz.csi:md5,1785ccc070672847330b9453ad9030ea",
+                "pos_test_mobilome.gff.gz:md5,026b7ff92dbe7b08129027ceeb15563f",
+                "pos_test_user_mobilome_clean.gff.gz:md5,951247d87b7f9359dd60c80128ed016a",
+                "pos_test_user_mobilome_clean.gff.gz.csi:md5,30e2f523ba350e910da47b4b9b759720",
+                "pos_test_user_mobilome_extra.gff.gz:md5,7167af99b4495b8cc188a926022e2694",
+                "pos_test_user_mobilome_extra.gff.gz.csi:md5,f514ca6edcbfdc927c94cc86f207c6fe",
+                "pos_test_user_mobilome_full.gff.gz:md5,06bed19fbbb50b553cbd6f4ce90dbdcc",
+                "pos_test_user_mobilome_full.gff.gz.csi:md5,f68611e5cbaffc9888de12dc412b0203",
                 "pos_test_discarded_mge.txt:md5,a5cf4cfdab4cf37b5dbe71453f3371f8",
-                "pos_test_mobilome.fasta.gz:md5,fd71220c3ccaa195b0d5816987ed5425",
-                "pos_test_overlap_report.txt:md5,656234fc2ec2f7dfe07eb640cb701d15",
+                "pos_test_mobilome.fasta.gz:md5,295323142d19fbbbe7ae816f56d1a400",
+                "pos_test_overlap_report.txt:md5,009fc7891415a47b1f07493101509b73",
                 "pos_test_100kb_contigs.1.bed:md5,5fc423afbe8bd4865b10d1c4aacf13d4",
                 "pos_test_5kb_contigs_plasmid_summary.tsv:md5,d83b9369661d2d44fdc638ed77503d9f",
                 "pos_test_5kb_contigs_virus_summary.tsv:md5,82bfc810082a45375348443034f0e5a7",
                 "pos_test_ice_genes.tsv:md5,f46e330b6ff07ccf7b8e05af1d1190d4",
                 "pos_test_ices.tsv:md5,8f11aa31e6d2a489f56129b4fd324752",
-                "contig_1.gbk:md5,d1b173b05ecbc4ba20a64320ffa1b04e",
-                "contig_5.gbk:md5,09b81c2a5bcc8e0d9c1c4348b0d62f34",
-                "pos_test_5kb_contigs.summary:md5,f16381b08502af0a27ca474fe851e00c",
+                "contig_dummy.gbk:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "contig_dummy.summary:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "pos_test_1kb_contigs.fasta.tsv:md5,8e248071a3d84f1fbd5ec547f77ed6b2",
                 "pos_test_virify_hq.gff:md5,28b682a47acea24c5e6371258678b739",
                 "pos_test_100kb_contigs.fasta:md5,71acd728dd46414bf8746ea7d6a12724",
@@ -120,10 +118,10 @@
                 
             ]
         ],
+        "timestamp": "2026-03-23T21:31:42.170111207",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.7"
-        },
-        "timestamp": "2025-11-17T15:51:58.843004"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/workflows/mobilomeannotation.nf
+++ b/workflows/mobilomeannotation.nf
@@ -147,7 +147,7 @@ workflow MOBILOMEANNOTATION {
     GENOMAD(RENAME.out.contigs_5kb, genomad_db.first())
     ch_versions = ch_versions.mix(GENOMAD.out.versions)
 
-    INTEGRONFINDER(RENAME.out.contigs_5kb)
+    INTEGRONFINDER(RENAME.out.contigs_100kb)
     ch_versions = ch_versions.mix(INTEGRONFINDER.out.versions)
 
     ISESCAN(RENAME.out.contigs_1kb)


### PR DESCRIPTION
This change is two-fold:
- Bug fix - https://github.com/gem-pasteur/Integron_Finder/issues/92 (attempting to work around this)
- Performance improvement - This tool creates a large number of folders and files (one folder per contig, plus several files within each). This is problematic for metagenomes. After discussing with @Ales-ibt, we decided to run this tool only on the largest contigs to mitigate this issue.