### PR TITLE
Allow gff3 extensions in input

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -21,12 +21,12 @@
             },
             "user_proteins_gff": {
                 "type": "string",
-                "pattern": "^\\S+\\.(gff)(\\.gz)?$",
+                "pattern": "^\\S+\\.(gff3?)(\\.gz)?$",
                 "errorMessage": "The file with proteins detected for the assembly needs to be a gff3 file (optionally compressed with .gz)"
             },
             "virify_gff": {
                 "type": "string",
-                "pattern": "^\\S+\\.(gff)(\\.gz)?$",
+                "pattern": "^\\S+\\.(gff3?)(\\.gz)?$",
                 "errorMessage": "The VIRify file generated for the assembly needs to be a gff3 file (optionally compressed with .gz)"
             }
         },


### PR DESCRIPTION
A small change to allow the .gff3 file extension for user_proteins_gff and virify_gff input fields.