### PR TITLE
Add check for u_prot_len in intersection condition (#86)

### DIFF
--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -275,7 +275,7 @@ def gff_updater(
                         mge_label = mob_types[(contig, mge_start, mge_end)]
                         intersection = len(list(set(mge_range) & set(u_prot_range)))
                         
-                        if intersection > 0:
+                        if intersection > 0 and u_prot_len > 0:
                             u_prot_cov = float(intersection) / float(u_prot_len)
                             if u_prot_cov > COV_THRESHOLD:
                                 passenger_flag = 1

--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -263,7 +263,7 @@ def gff_updater(
                 u_prot_start = int(start)
                 u_prot_end = int(end)
                 u_prot_range = range(u_prot_start, u_prot_end + 1)
-                u_prot_len = u_prot_end - u_prot_start
+                u_prot_len = u_prot_end - u_prot_start + 1
                 passenger_flag = 0
                 mge_loc = []
                 
@@ -275,7 +275,7 @@ def gff_updater(
                         mge_label = mob_types[(contig, mge_start, mge_end)]
                         intersection = len(list(set(mge_range) & set(u_prot_range)))
                         
-                        if intersection > 0 and u_prot_len > 0:
+                        if intersection > 0:
                             u_prot_cov = float(intersection) / float(u_prot_len)
                             if u_prot_cov > COV_THRESHOLD:
                                 passenger_flag = 1


### PR DESCRIPTION
This prevents to include in the comparsion features of length = 0 that could be generated by Bakta. 

Example:
```bash
MGYG000000133_4	Bakta	gap	120089	120089	.	.	.	ID=BGEPMDPGIH_3179;Name=gap (1 bp);product=gap (1 bp)
```

This fix issue #83 