### PR TITLE
Fix user protein length calculation and coverage condition

### DIFF
--- a/bin/gff_mapping.py
+++ b/bin/gff_mapping.py
@@ -263,7 +263,7 @@ def gff_updater(
                 u_prot_start = int(start)
                 u_prot_end = int(end)
                 u_prot_range = range(u_prot_start, u_prot_end + 1)
-                u_prot_len = u_prot_end - u_prot_start
+                u_prot_len = u_prot_end - u_prot_start + 1
                 passenger_flag = 0
                 mge_loc = []
                 
@@ -275,7 +275,7 @@ def gff_updater(
                         mge_label = mob_types[(contig, mge_start, mge_end)]
                         intersection = len(list(set(mge_range) & set(u_prot_range)))
                         
-                        if intersection > 0 and u_prot_len > 0:
+                        if intersection > 0:
                             u_prot_cov = float(intersection) / float(u_prot_len)
                             if u_prot_cov > COV_THRESHOLD:
                                 passenger_flag = 1


### PR DESCRIPTION
Adjusted the calculation of user protein length and modified the condition for calculating coverage.

GFF3 uses 1-based fully closed coordinates, so feature length should be computed as end - start + 1, not end - start. When a feature is exactly 1 bp (start == end, which is valid GFF3), the current formula returns 0 and triggers the division by zero. The fix is to correct the length calculation.