### PR TITLE
Fixing the tRNA coordinates at the edge of the contig

### DIFF
--- a/.github/workflows/full_pipeline_test.yml
+++ b/.github/workflows/full_pipeline_test.yml
@@ -30,6 +30,22 @@ jobs:
         with:
           install-pdiff: true
 
+      - name: Free disk space
+        run: |
+          echo "Disk before cleanup:"
+          df -h
+
+          docker system prune -af || true
+          docker volume prune -f || true
+
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+
+          echo "Disk after cleanup:"
+          df -h
+
       - name: Fetch ICEfinder2-lite test databases
         run: |
           mkdir -p tests/reference_databases/icefinder

--- a/bin/trnas_integrator.py
+++ b/bin/trnas_integrator.py
@@ -35,10 +35,45 @@ class Feature:
     original_id: Optional[str] = None  # For tracking original prodigal IDs
 
 
-def parse_aragorn_output(file_path: str) -> Dict[str, List[Feature]]:
+def parse_contig_lengths_from_gff(file_path: str) -> Dict[str, int]:
+    """
+    Parse contig lengths from Prodigal GFF comment lines.
+
+    Expected Prodigal format:
+    # Sequence Data: seqnum=1;seqlen=118594;seqhdr="contig_1"
+    """
+    contig_lengths = {}
+
+    with gzip.open(file_path, "rt") as f:
+        for line_num, line in enumerate(f, start=1):
+            if not line.startswith("# Sequence Data:"):
+                continue
+
+            seqhdr_match = re.search(r'seqhdr="([^"]+)"', line)
+            seqlen_match = re.search(r"seqlen=(\d+)", line)
+
+            if not seqhdr_match or not seqlen_match:
+                print(
+                    f"Line {line_num}: Warning: could not parse Prodigal "
+                    f"Sequence Data line: {line.strip()}"
+                )
+                continue
+
+            contig_id = seqhdr_match.group(1)
+            contig_len = int(seqlen_match.group(1))
+            contig_lengths[contig_id] = contig_len
+
+    return contig_lengths
+
+
+def parse_aragorn_output(
+    file_path: str,
+    contig_lengths: Dict[str, int],
+) -> Dict[str, List[Feature]]:
     """
     Parse aragorn output following prokka rules.
     Returns dictionary with contig names as keys and tRNA features as values.
+    Fix coordinates whn start = 0 or end > contig length
     """
     trnas_per_contig = defaultdict(list)
     current_contig = None
@@ -86,6 +121,18 @@ def parse_aragorn_output(file_path: str) -> Dict[str, List[Feature]]:
             is_reverse = coord_match.group(1) == "c"
             start = int(coord_match.group(2))
             end = int(coord_match.group(3))
+
+            # Aragorn can report start as 0 for features beginning at the first base.
+            # GFF coordinates are 1-based, so convert 0 to 1.
+            if start == 0:
+                start = 1
+
+            # Clamp tRNA end coordinate to contig length if Aragorn reports one base
+            # beyond the contig boundary.
+            if current_contig in contig_lengths:
+                contig_len = contig_lengths[current_contig]
+                if end >= contig_len:
+                    end = contig_len
 
             # Apply prokka validation rules
             if start > end:
@@ -434,8 +481,12 @@ def main():
     print()
 
     # Parse input files
+    print("Parsing contig lengths from Prodigal GFF...")
+    contig_lengths = parse_contig_lengths_from_gff(args.prodigal_gff)
+    print(f"Found lengths for {len(contig_lengths)} contigs")
+
     print("Parsing Aragorn output...")
-    trna_features = parse_aragorn_output(args.aragorn)
+    trna_features = parse_aragorn_output(args.aragorn, contig_lengths)
     total_trnas = sum(len(features) for features in trna_features.values())
     print(
         f"Found {total_trnas} tRNA/tmRNA features across {len(trna_features)} contigs"
@@ -466,7 +517,7 @@ def main():
 
     # Write outputs
     print(f"\nWriting GFF3 output to: {args.prefix}_merged.gff")
-    write_gff3(integrated_features, args.prefix)
+    write_gff3(integrated_features, args.prefix, contig_lengths)
 
     print(f"\nWriting renamed faa output to: {args.prefix}_renamed.faa")
     write_faa(args.prodigal_faa, id_mapping, args.prefix)

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -40,8 +40,8 @@
                 "neg_test_mobilome_clean.gff.gz.csi:md5,812c0d392568c42e03b6f375de8b6424",
                 "neg_test_mobilome_extra.gff.gz:md5,df19e1b84ba6f691d20c72b397c88abf",
                 "neg_test_mobilome_extra.gff.gz.csi:md5,812c0d392568c42e03b6f375de8b6424",
-                "neg_test_mobilome_full.gff.gz:md5,9eb24c75ce7bf249344222195faa1a3c",
-                "neg_test_mobilome_full.gff.gz.csi:md5,43c73f50d36a9f405cdc9cd8d94b8ee5",
+                "neg_test_mobilome_full.gff.gz:md5,ee92649c1d9d35d011c2c5fe89aa179e",
+                "neg_test_mobilome_full.gff.gz.csi:md5,0b9127cbb5eefb5f4a4321380f61dee4",
                 "neg_test_discarded_mge.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "neg_test_mobilome.fasta.gz:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "neg_test_overlap_report.txt:md5,009fc7891415a47b1f07493101509b73",
@@ -60,7 +60,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2026-07-08T12:39:38.075625691"
+        "timestamp": "2026-07-10T10:25:03.437609355"
     },
     "Pathofact integration test with annotation manifest. Expected a report of proteins with relevant annotation": {
         "content": [
@@ -189,8 +189,8 @@
                 "pos_test_mobilome_clean.gff.gz.csi:md5,f7a115be3e7e1a4075ef62afa2299119",
                 "pos_test_mobilome_extra.gff.gz:md5,f159be0e6bf696daafe21ea4e15ceaed",
                 "pos_test_mobilome_extra.gff.gz.csi:md5,f47eb2fcc1ed57c8fe066bd356f7e506",
-                "pos_test_mobilome_full.gff.gz:md5,fba2d8f1f31cc8c1fd9f273d665b4084",
-                "pos_test_mobilome_full.gff.gz.csi:md5,ad4fde7b3e6b0cf82038cdccd773d843",
+                "pos_test_mobilome_full.gff.gz:md5,5d5db8d52fefd1322e9075f9d0cc0d79",
+                "pos_test_mobilome_full.gff.gz.csi:md5,d702d193e560196a6df48ad37a399b34",
                 "pos_test_discarded_mge.txt:md5,cb95cbdbde35c62c9ec7a7f7322f3a9d",
                 "pos_test_mobilome.fasta.gz:md5,a2aef37a55f756b5a7ebc48065b165cc",
                 "pos_test_overlap_report.txt:md5,dd99d385dd3d942b3a9d2cd89ccd726b",
@@ -215,6 +215,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2026-07-08T12:20:37.258533475"
+        "timestamp": "2026-07-10T10:03:47.680208496"
     }
 }


### PR DESCRIPTION
Aragorn report end coordinates one position beyond the end of the contig, triggering antismash to fail. In this PR we are also fixing start = 0 just in case. 

Thanks for reviewing!